### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [11,17-ea]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java }}
         distribution: 'zulu'
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,6 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'zulu'
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. I also added JDK 17-ea since it will be the next LTS release 🥇. 
